### PR TITLE
Basic views to fetch music user token

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 # does not style anything found in .gitignore, and also...
 *.md
+*.handlebars # will mess up formatting of code more than it fixes it

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 # does not style anything found in .gitignore, and also...
 *.md
-*.handlebars # will mess up formatting of code more than it fixes it
+*.handlebars

--- a/app.js
+++ b/app.js
@@ -1,0 +1,18 @@
+import express from "express";
+import configRoutes from "./routes/index.js";
+import exphbs from "express-handlebars";
+
+const app = express();
+
+// app.use("/public", express.static("public"));
+app.use(express.json()); // for http bodies
+app.use(express.urlencoded({ extended: true }));
+
+app.engine("handlebars", exphbs.engine({ defaultLayout: "main" }));
+app.set("view engine", "handlebars");
+
+configRoutes(app);
+
+app.listen(3000, () => {
+    console.log("Server running! http://localhost:3000");
+});

--- a/helpers/authentication.js
+++ b/helpers/authentication.js
@@ -125,11 +125,9 @@ const getPKCECodes = async (length = 64) => {
     };
 };
 
-
-
 /**
  * generates a JSON Web Token (JWT) signed developer token used to access the apple music api
- * 
+ *
  * @returns {string}    signed JWT developer token
  */
 const AMGenerateDevToken = () => {
@@ -147,10 +145,8 @@ const AMGenerateDevToken = () => {
         exp: currTime + 3600 // expires in one hour
     };
 
-    return jwt.sign(payload, secret, {header: header}); // return the encoded dev token
+    return jwt.sign(payload, secret, { header: header }); // return the encoded dev token
 };
-
-
 
 const exportedMethods = {
     SPGetAuthorizationURL,

--- a/helpers/authentication.js
+++ b/helpers/authentication.js
@@ -4,6 +4,7 @@
 
 import { config } from "dotenv";
 import errorMessage from "./error.js";
+import jwt from "jsonwebtoken";
 
 const MOD_NAME = "authentication.js";
 
@@ -124,12 +125,40 @@ const getPKCECodes = async (length = 64) => {
     };
 };
 
+
+
+/**
+ * generates a JSON Web Token (JWT) signed developer token used to access the apple music api
+ * 
+ * @returns {string}    signed JWT developer token
+ */
+const AMGenerateDevToken = () => {
+    let secret = process.env.AM_SECRET;
+    secret = secret.replaceAll("\\n", "\n"); // replace all "\n" literals with proper newline
+    const header = {
+        alg: "ES256",
+        kid: process.env.AM_KEY_ID
+    };
+
+    const currTime = Math.floor(Date.now() / 1000); // unix epoch in seconds
+    const payload = {
+        iss: process.env.AM_TEAM_ID,
+        iat: currTime,
+        exp: currTime + 3600 // expires in one hour
+    };
+
+    return jwt.sign(payload, secret, {header: header}); // return the encoded dev token
+};
+
+
+
 const exportedMethods = {
     SPGetAuthorizationURL,
     generatePKCEString,
     encrypt,
     base64encode,
-    getPKCECodes
+    getPKCECodes,
+    AMGenerateDevToken
 };
 
 export default exportedMethods;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "type": "module",
     "scripts": {
         "start": "node app.js",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "commit": "npx prettier . --write && git add -A && git commit"
     },
     "author": "CS 546 Group 7",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
         "axios": "^1.6.7",
         "dotenv": "^16.4.5",
         "express": "^4.18.3",
+        "express-handlebars": "^7.1.2",
+        "jsonwebtoken": "^9.0.2",
         "prettier": "^3.2.5"
     }
 }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -61,12 +61,15 @@ router.route("/spotify/success").get(async (req, res) => {
     }
 });
 
-router.route("/apple-music").get(async (req, res) => {
-    const devToken = authentication.AMGenerateDevToken();
-    return res.render("auth/apple-music", { title: "am test", AMDevToken: devToken });
-})
-.post(async (req, res) => {
-    
-});
+router
+    .route("/apple-music")
+    .get(async (req, res) => {
+        const devToken = authentication.AMGenerateDevToken();
+        return res.render("auth/apple-music", {
+            title: "am test",
+            AMDevToken: devToken
+        });
+    })
+    .post(async (req, res) => {});
 
 export default router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -16,6 +16,10 @@ const router = Router();
 
 const codes = await authentication.getPKCECodes(64);
 
+router.route("/").get(async (req, res) => {
+    return res.render("auth", { title: "Authorize" });
+});
+
 router.route("/spotify").get((req, res) => {
     const authURL = authentication.SPGetAuthorizationURL(
         codes["codeChallenge"]
@@ -55,6 +59,14 @@ router.route("/spotify/success").get(async (req, res) => {
     } catch (e) {
         return res.status(500).json({ error: e });
     }
+});
+
+router.route("/apple-music").get(async (req, res) => {
+    const devToken = authentication.AMGenerateDevToken();
+    return res.render("auth/apple-music", { title: "am test", AMDevToken: devToken });
+})
+.post(async (req, res) => {
+    
 });
 
 export default router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -16,7 +16,7 @@ const router = Router();
 
 const codes = await authentication.getPKCECodes(64);
 
-router.route("/").get(async (req, res) => {
+router.route("/").get((req, res) => {
     return res.render("auth", { title: "Authorize" });
 });
 
@@ -61,15 +61,23 @@ router.route("/spotify/success").get(async (req, res) => {
     }
 });
 
-router
-    .route("/apple-music")
-    .get(async (req, res) => {
-        const devToken = authentication.AMGenerateDevToken();
-        return res.render("auth/apple-music", {
-            title: "am test",
-            AMDevToken: devToken
-        });
-    })
-    .post(async (req, res) => {});
+router.route("/apple-music").get((req, res) => {
+    const devToken = authentication.AMGenerateDevToken();
+    return res.render("auth/apple-music", {
+        title: "am test",
+        AMDevToken: devToken
+    });
+});
+
+router.route("/apple-music/success").get(async (req, res) => {
+    let mut = req.query.mut || null; // try to get music user token from query params
+    if (mut === null) {
+        return res
+            .status(500)
+            .json({ error: "issue getting apple music user token" });
+    }
+
+    return res.json({ authData: req.query.mut, status: "success" }); // TODO: don't actually display this to user, handle and associate access token with user profile to use for api requests
+});
 
 export default router;

--- a/views/auth.handlebars
+++ b/views/auth.handlebars
@@ -1,0 +1,7 @@
+<h1>Hello, world!</h1>
+
+<h3>This is the {{ title }} page.</h3>
+
+<a href="/auth/spotify">Authorize Spotify account</a>
+
+<a href="/auth/apple-music">Authorize Apple Music account</a>

--- a/views/auth/apple-music.handlebars
+++ b/views/auth/apple-music.handlebars
@@ -1,0 +1,29 @@
+<script src="https://js-cdn.music.apple.com/musickit/v3/musickit.js" async></script> <!-- include musickit web lib -->
+
+<script>
+    document.addEventListener("musickitloaded", async function () {
+        try { // reference for implementation: https://js-cdn.music.apple.com/musickit/v3/docs/index.html?path=/story/get-started--page
+            await MusicKit.configure({
+                developerToken: "{{AMDevToken}}",
+                app: {
+                    name: "Tweeter",
+                    build: "0.0.1",
+                },
+            });
+        } catch (e) {
+            alert(`Error: ${e}`);
+        }
+
+        // MusicKit instance is available
+        let music = MusicKit.getInstance();
+        document.getElementById("musickit-js-auth").addEventListener("click", async () => {
+            const mut = await music.authorize();
+            alert(`got music user token! ${mut}`);
+        });
+    });
+</script>
+
+<h1>HELLO APPLEMUSIC AHHHHH</h1>
+
+<button id="musickit-js-auth">Hello</button>
+

--- a/views/auth/apple-music.handlebars
+++ b/views/auth/apple-music.handlebars
@@ -17,8 +17,9 @@
         // MusicKit instance is available
         let music = MusicKit.getInstance();
         document.getElementById("musickit-js-auth").addEventListener("click", async () => {
-            const mut = await music.authorize();
-            alert(`got music user token! ${mut}`);
+            const mut = await music.authorize(); // get music user token to store in db
+            await music.unauthorize(); // unauthorize to clear mut from browser cookies 
+            window.location.href = `/auth/apple-music/success?mut=${mut}`; // redirect to the success page
         });
     });
 </script>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>{{title}} - Tweeter</title>
+    {{!-- <link rel="stylesheet" href="/public/css/styles.css"> --}}
+</head>
+
+<body>
+    <main>
+        {{{body}}} 
+    </main>
+</body>
+
+</html>


### PR DESCRIPTION
Added basic views that are able to request and fetch the AM Music User Token (MUT) on the client side to send back to the server

Initialized `views` and `views/layouts/main.handlebars`

Added a command to `package.json`, being `npm run commit`, which will:
1. run Prettier on the whole project (`npx prettier . --write`)
2. stage all changes (`git add -A`)
3. commit the changes and present a prompt for a commit message `git commit`

The command does NOT push (`git push`), you must do that manually